### PR TITLE
Toolchain

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+### What
+
+[TODO: Short statement about what is changing.]
+
+### Why
+
+[TODO: Why this change is being made. Include any context required to understand the why.]
+
+### Known limitations
+
+[TODO or N/A]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,63 @@
+name: Rust
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  RUSTFLAGS: -D warnings
+
+jobs:
+
+  complete:
+    if: always()
+    needs: [fmt, build-and-test]
+    runs-on: ubuntu-latest
+    steps:
+    - if: contains(needs.*.result, 'failure')
+      run: exit 1
+
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: rustup update
+    - run: cargo fmt --all --check
+
+  build-and-test:
+    strategy:
+      matrix:
+        sys:
+        - os: ubuntu-latest
+          target: wasm32-unknown-unknown
+          profile: release
+          test: false
+        - os: ubuntu-latest
+          target: x86_64-unknown-linux-gnu
+          profile: test
+          test: true
+        - os: macos-latest
+          target: x86_64-apple-darwin
+          profile: test
+          test: true
+        - os: macos-latest
+          target: aarch64-apple-darwin
+          profile: test
+          test: false
+        - os: windows-latest
+          target: x86_64-pc-windows-msvc
+          profile: test
+          test: true
+    runs-on: ${{ matrix.sys.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - run: rustup update
+    - run: rustup target add ${{ matrix.sys.target }}
+    - run: cargo install --locked --version 0.5.14 cargo-hack
+    - run: cargo check --profile ${{ matrix.sys.profile }} --target ${{ matrix.sys.target }} --lib
+    - if: matrix.sys.test
+      run: cargo hack --feature-powerset check --profile ${{ matrix.sys.profile }} --target ${{ matrix.sys.target }} --bins --tests --examples --benches
+    - run: cargo build --profile ${{ matrix.sys.profile }} --target ${{ matrix.sys.target }}
+    - if: matrix.sys.test
+      run: cargo hack --feature-powerset test --profile ${{ matrix.sys.profile }} --target ${{ matrix.sys.target }}

--- a/Makefile
+++ b/Makefile
@@ -22,14 +22,14 @@ build:
 		done
 
 check:
-	cargo check --all-targets
-	cargo check --target wasm32-unknown-unknown
+	cargo hack --feature-powerset check --all-targets
+	cargo check --release --target wasm32-unknown-unknown
 
 watch:
 	cargo watch --clear --watch-when-idle --shell '$(MAKE)'
 
 fmt:
-	rustfmt $$(find . -type f -name '*.rs' -print)
+	cargo fmt --all
 
 clean:
 	cargo clean

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "stable"
+targets = ["wasm32-unknown-unknown"]
+components = ["rustc", "cargo", "rustfmt", "clippy", "rust-src"]


### PR DESCRIPTION
### What
Add `rust-toolchain.toml`, update Makefile to match other projects, add CI.

### Why
After seeing some issues with the way we were installing rustup in other repos in GitHub Actions I'm introducing `rust-toolchain.toml` to all the repos, and figured I may as well do this one too. It doesn't have a CI setup, so I'm copying over one as part of this. Lmk if you don't want CI yet and I can drop that from the PR.