### PR TITLE
Move outside-in test to tests folder

### DIFF
--- a/src/external.rs
+++ b/src/external.rs
@@ -11,6 +11,12 @@ use stellar_xdr::{
     HostFunction, ScBigInt, ScMap, ScMapEntry, ScObject, ScStatic, ScVal, ScVec, WriteXdr,
 };
 
+impl From<&Keypair> for Identifier {
+    fn from(kp: &Keypair) -> Self {
+        Identifier::Ed25519(kp.public.to_bytes())
+    }
+}
+
 pub trait ToScVal {
     fn to_scval(&self) -> Result<ScVal, ()>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,4 +13,3 @@ pub mod external;
 mod nonce;
 pub mod public_types;
 mod storage_types;
-mod test;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,8 +1,8 @@
-use stellar_token_contract::external;
 use ed25519_dalek::Keypair;
-use external::{MessageWithoutNonce as ContractFn};
+use external::MessageWithoutNonce as ContractFn;
 use rand::thread_rng;
 use stellar_contract_sdk::Env;
+use stellar_token_contract::external;
 
 fn generate_keypair() -> Keypair {
     Keypair::generate(&mut thread_rng())

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,17 +1,8 @@
-#![cfg(test)]
-#![cfg(feature = "external")]
-
-use crate::external;
+use stellar_token_contract::external;
 use ed25519_dalek::Keypair;
-use external::{Identifier, MessageWithoutNonce as ContractFn};
+use external::{MessageWithoutNonce as ContractFn};
 use rand::thread_rng;
 use stellar_contract_sdk::Env;
-
-impl From<&Keypair> for Identifier {
-    fn from(kp: &Keypair) -> Self {
-        Identifier::Ed25519(kp.public.to_bytes())
-    }
-}
 
 fn generate_keypair() -> Keypair {
     Keypair::generate(&mut thread_rng())


### PR DESCRIPTION
### What
Move `test.rs` to `tests` folder.

### Why
The `test.rs` file looks like outside in testing of the package, which are common to place in the `tests` folder. The advantage of it is it will provide the same experience as someone writing code from another crate, from another contract in using the crates fns directly.