### PR TITLE
Update stellar-contract-sdk and rename external feature to testutils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,7 +564,7 @@ source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=52344714#52
 [[package]]
 name = "stellar-contract-macros"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-sdk?rev=11a0031d#11a0031dbba4a19fc57d92bf31ae8c2de67ef485"
+source = "git+https://github.com/stellar/rs-stellar-contract-sdk?rev=d7dde0c5#d7dde0c58bffda5d4ae786d3a23d07283b5c2b2d"
 dependencies = [
  "darling",
  "itertools",
@@ -577,7 +577,7 @@ dependencies = [
 [[package]]
 name = "stellar-contract-sdk"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-sdk?rev=11a0031d#11a0031dbba4a19fc57d92bf31ae8c2de67ef485"
+source = "git+https://github.com/stellar/rs-stellar-contract-sdk?rev=d7dde0c5#d7dde0c58bffda5d4ae786d3a23d07283b5c2b2d"
 dependencies = [
  "ed25519-dalek",
  "stellar-contract-env-guest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,16 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = ["export"]
 export = []
-external = ["stellar-contract-sdk/testutils", "dep:ed25519-dalek", "dep:num-bigint", "dep:stellar-xdr", "stellar-xdr?/num-bigint"]
+testutils = ["stellar-contract-sdk/testutils", "dep:ed25519-dalek", "dep:num-bigint", "dep:stellar-xdr", "stellar-xdr?/num-bigint"]
 
 [dependencies]
 ed25519-dalek = { version = "1.0.1", optional = true }
 num-bigint = { version = "0.4", optional = true }
-stellar-contract-sdk = { git = "https://github.com/stellar/rs-stellar-contract-sdk", rev = "11a0031d" }
+stellar-contract-sdk = { git = "https://github.com/stellar/rs-stellar-contract-sdk", rev = "d7dde0c5" }
 # stellar-contract-sdk = { path = "../rs-stellar-contract-sdk/sdk" }
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "94e01c7b", features = ["next"], optional = true }
 # stellar-xdr = { path = "../rs-stellar-xdr", features = ["next"], optional = true }
 
 [dev-dependencies]
-stellar-token-contract = { path = ".", features = ["export", "external"] }
+stellar-token-contract = { path = ".", features = ["export", "testutils"] }
 rand = { version = "0.7.3" }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -43,7 +43,7 @@ pub trait TokenTrait {
 
 pub struct Token;
 
-#[contractimpl(export_if = "export", tests_if = "external")]
+#[contractimpl(export_if = "export")]
 impl TokenTrait for Token {
     fn initialize(e: Env, admin: Identifier) {
         if has_administrator(&e) {

--- a/src/external.rs
+++ b/src/external.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "external")]
+#![cfg(feature = "testutils")]
 
 use std::vec::Vec;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-#[cfg(any(test, feature = "external"))]
+#[cfg(any(test, feature = "testutils"))]
 #[macro_use]
 extern crate std;
 


### PR DESCRIPTION
### What
Update stellar-contract-sdk and rename external feature to testutils.

### Why
Updating following https://github.com/stellar/rs-stellar-contract-sdk/pull/288.

@jonjove I think from our conversation earlier today you were okay with this. Let me know if I misunderstood.