### PR TITLE
Use invoke_external macro-generated code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,7 +508,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-contract-env-common"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=85b352af#85b352afa70530d4561b273abd0462fe3440dfc5"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=54d1f82#54d1f8299fd067876a317f8c79bb2177c35abbfa"
 dependencies = [
  "static_assertions",
  "stellar-contract-env-macros",
@@ -518,7 +518,7 @@ dependencies = [
 [[package]]
 name = "stellar-contract-env-guest"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=85b352af#85b352afa70530d4561b273abd0462fe3440dfc5"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=54d1f82#54d1f8299fd067876a317f8c79bb2177c35abbfa"
 dependencies = [
  "static_assertions",
  "stellar-contract-env-common",
@@ -527,7 +527,7 @@ dependencies = [
 [[package]]
 name = "stellar-contract-env-host"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=85b352af#85b352afa70530d4561b273abd0462fe3440dfc5"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=54d1f82#54d1f8299fd067876a317f8c79bb2177c35abbfa"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -548,7 +548,7 @@ dependencies = [
 [[package]]
 name = "stellar-contract-env-macros"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=85b352af#85b352afa70530d4561b273abd0462fe3440dfc5"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=54d1f82#54d1f8299fd067876a317f8c79bb2177c35abbfa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -559,12 +559,12 @@ dependencies = [
 [[package]]
 name = "stellar-contract-env-panic-handler-wasm32-unreachable"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=85b352af#85b352afa70530d4561b273abd0462fe3440dfc5"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=54d1f82#54d1f8299fd067876a317f8c79bb2177c35abbfa"
 
 [[package]]
 name = "stellar-contract-macros"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-sdk?rev=c7eb7129#c7eb7129c92617bb5d17a3b1aeba7c5c77346c5f"
+source = "git+https://github.com/stellar/rs-stellar-contract-sdk?rev=764fc12#764fc126778146bdc6c56ec5e10e220cd17be9e1"
 dependencies = [
  "darling",
  "itertools",
@@ -577,7 +577,7 @@ dependencies = [
 [[package]]
 name = "stellar-contract-sdk"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-sdk?rev=c7eb7129#c7eb7129c92617bb5d17a3b1aeba7c5c77346c5f"
+source = "git+https://github.com/stellar/rs-stellar-contract-sdk?rev=764fc12#764fc126778146bdc6c56ec5e10e220cd17be9e1"
 dependencies = [
  "ed25519-dalek",
  "stellar-contract-env-guest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,9 +361,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc2916cde080c1876ff40292a396541241fe0072ef928cd76582e9ea5d60d2"
+checksum = "c278e965f1d8cf32d6e0e96de3d3e79712178ae67986d9cf9151f51e95aac89b"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ testutils = ["stellar-contract-sdk/testutils", "dep:ed25519-dalek", "dep:num-big
 [dependencies]
 ed25519-dalek = { version = "1.0.1", optional = true }
 num-bigint = { version = "0.4", optional = true }
-stellar-contract-sdk = { git = "https://github.com/stellar/rs-stellar-contract-sdk", rev = "c7eb7129" }
+stellar-contract-sdk = { git = "https://github.com/stellar/rs-stellar-contract-sdk", rev = "764fc12" }
 # stellar-contract-sdk = { path = "../rs-stellar-contract-sdk/sdk" }
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "94e01c7b", features = ["next"], optional = true }
 # stellar-xdr = { path = "../rs-stellar-xdr", features = ["next"], optional = true }

--- a/src/external.rs
+++ b/src/external.rs
@@ -1,423 +1,211 @@
 #![cfg(feature = "testutils")]
 
-use std::vec::Vec;
+use crate::public_types::{
+    Authorization, Identifier, KeyedAuthorization, KeyedEd25519Authorization, Message, MessageV0,
+};
+use ed25519_dalek::Keypair;
+use stellar_contract_sdk::testutils::ed25519::Sign;
+use stellar_contract_sdk::{BigInt, Binary, Env, EnvVal, FixedBinary, IntoEnvVal, TryIntoVal, Vec};
 
-use ed25519_dalek::{Keypair, Signer};
-use num_bigint::BigInt;
-use stellar_contract_sdk::xdr::{HostFunction, ScMap, ScMapEntry, ScObject, ScVal, WriteXdr};
-use stellar_contract_sdk::{Binary, Env, TryIntoVal};
-
-pub type U256 = [u8; 32];
-pub type U512 = [u8; 64];
-
-#[derive(Clone)]
-pub enum Identifier {
-    Contract(U256),
-    Ed25519(U256),
-    Account(U256),
+pub fn register_test_contract(e: &Env, contract_id: &[u8; 32]) {
+    let contract_id = Binary::from_array(e, *contract_id);
+    e.register_contract(contract_id, crate::contract::Token {});
 }
 
-impl TryInto<ScVal> for &Identifier {
-    type Error = ();
-    fn try_into(self) -> Result<ScVal, Self::Error> {
-        match self {
-            Identifier::Contract(x) => ("Contract", x).try_into(),
-            Identifier::Ed25519(x) => ("Ed25519", x).try_into(),
-            Identifier::Account(x) => ("Account", x).try_into(),
+pub use crate::contract::__allowance::call_external as allowance;
+pub use crate::contract::__approve::call_external as approve;
+pub use crate::contract::__balance::call_external as balance;
+pub use crate::contract::__burn::call_external as burn;
+pub use crate::contract::__decimals::call_external as decimals;
+pub use crate::contract::__freeze::call_external as freeze;
+pub use crate::contract::__initialize::call_external as initialize;
+pub use crate::contract::__is_frozen::call_external as is_frozen;
+pub use crate::contract::__mint::call_external as mint;
+pub use crate::contract::__name::call_external as name;
+pub use crate::contract::__nonce::call_external as nonce;
+pub use crate::contract::__set_admin::call_external as set_admin;
+pub use crate::contract::__symbol::call_external as symbol;
+pub use crate::contract::__unfreeze::call_external as unfreeze;
+pub use crate::contract::__xfer::call_external as xfer;
+pub use crate::contract::__xfer_from::call_external as xfer_from;
+
+pub fn to_ed25519(e: &Env, kp: &Keypair) -> Identifier {
+    Identifier::Ed25519(kp.public.to_bytes().try_into_val(e).unwrap())
+}
+
+pub struct Token {
+    env: Env,
+    contract_id: Binary,
+}
+
+impl Token {
+    pub fn new(env: &Env, contract_id: &[u8; 32]) -> Self {
+        Self {
+            env: env.clone(),
+            contract_id: Binary::from_slice(env, contract_id),
         }
     }
-}
 
-impl TryInto<ScVal> for Identifier {
-    type Error = ();
-    fn try_into(self) -> Result<ScVal, Self::Error> {
-        (&self).try_into()
+    pub fn initialize(&mut self, admin: &Identifier, decimals: u32, name: &str, symbol: &str) {
+        let name: Binary = Binary::from_slice(&self.env, name.as_bytes());
+        let symbol: Binary = Binary::from_slice(&self.env, symbol.as_bytes());
+        initialize(
+            &mut self.env,
+            &self.contract_id,
+            admin,
+            &decimals,
+            &name,
+            &symbol,
+        )
     }
-}
 
-#[derive(Clone)]
-pub struct KeyedEd25519Authorization {
-    pub public_key: U256,
-    pub signature: U512,
-}
+    pub fn nonce(&mut self, id: &Identifier) -> BigInt {
+        nonce(&mut self.env, &self.contract_id, id)
+    }
 
-impl TryInto<ScVal> for &KeyedEd25519Authorization {
-    type Error = ();
-    fn try_into(self) -> Result<ScVal, Self::Error> {
-        let mut map = Vec::new();
-        map.push(ScMapEntry {
-            key: "public_key".try_into()?,
-            val: (&self.public_key).try_into()?,
+    pub fn allowance(&mut self, from: &Identifier, spender: &Identifier) -> BigInt {
+        allowance(&mut self.env, &self.contract_id, from, spender)
+    }
+
+    pub fn approve(&mut self, from: &Keypair, spender: &Identifier, amount: &BigInt) {
+        let mut args: Vec<EnvVal> = Vec::new(&self.env);
+        args.push(spender.clone().into_env_val(&self.env));
+        args.push(amount.clone().into_env_val(&self.env));
+        let msg = Message::V0(MessageV0 {
+            nonce: self.nonce(&to_ed25519(&self.env, from)),
+            domain: crate::cryptography::Domain::Approve as u32,
+            parameters: args,
         });
-        map.push(ScMapEntry {
-            key: "signature".try_into()?,
-            val: (&self.signature).try_into()?,
+        let auth = KeyedAuthorization::Ed25519(KeyedEd25519Authorization {
+            public_key: FixedBinary::from_array(&self.env, from.public.to_bytes()),
+            signature: from.sign(msg).unwrap().try_into_val(&self.env).unwrap(),
         });
-        Ok(ScVal::Object(Some(ScObject::Map(ScMap(map.try_into()?)))))
-    }
-}
-
-// TODO: Add other branches
-#[derive(Clone)]
-pub enum Authorization {
-    Ed25519(U512),
-}
-
-impl TryInto<ScVal> for &Authorization {
-    type Error = ();
-    fn try_into(self) -> Result<ScVal, Self::Error> {
-        match self {
-            Authorization::Ed25519(x) => ("Ed25519", x).try_into(),
-        }
-    }
-}
-
-// TODO: Add other branches
-#[derive(Clone)]
-pub enum KeyedAuthorization {
-    Ed25519(KeyedEd25519Authorization),
-}
-
-impl TryInto<ScVal> for &KeyedAuthorization {
-    type Error = ();
-    fn try_into(self) -> Result<ScVal, Self::Error> {
-        match self {
-            KeyedAuthorization::Ed25519(x) => ("Ed25519", x).try_into(),
-        }
-    }
-}
-
-pub enum MessageWithoutNonce {
-    Approve(Identifier, BigInt),
-    Transfer(Identifier, BigInt),
-    TransferFrom(Identifier, Identifier, BigInt),
-    Burn(Identifier, BigInt),
-    Freeze(Identifier),
-    Mint(Identifier, BigInt),
-    SetAdministrator(Identifier),
-    Unfreeze(Identifier),
-}
-
-pub struct Message(pub BigInt, pub MessageWithoutNonce);
-
-impl TryInto<ScVal> for &Message {
-    type Error = ();
-    fn try_into(self) -> Result<ScVal, Self::Error> {
-        let mut map = Vec::new();
-        match self {
-            Message(nonce, MessageWithoutNonce::Approve(id, amount)) => {
-                map.push(ScMapEntry {
-                    key: "domain".try_into()?,
-                    val: 0u32.into(),
-                });
-                map.push(ScMapEntry {
-                    key: "nonce".try_into()?,
-                    val: nonce.try_into()?,
-                });
-                map.push(ScMapEntry {
-                    key: "parameters".try_into()?,
-                    val: (id, amount).try_into()?,
-                });
-            }
-            Message(nonce, MessageWithoutNonce::Transfer(to, amount)) => {
-                map.push(ScMapEntry {
-                    key: "domain".try_into()?,
-                    val: 1u32.into(),
-                });
-                map.push(ScMapEntry {
-                    key: "nonce".try_into()?,
-                    val: nonce.try_into()?,
-                });
-                map.push(ScMapEntry {
-                    key: "parameters".try_into()?,
-                    val: (to, amount).try_into()?,
-                });
-            }
-            Message(nonce, MessageWithoutNonce::TransferFrom(from, to, amount)) => {
-                map.push(ScMapEntry {
-                    key: "domain".try_into()?,
-                    val: 2u32.into(),
-                });
-                map.push(ScMapEntry {
-                    key: "nonce".try_into()?,
-                    val: nonce.try_into()?,
-                });
-                map.push(ScMapEntry {
-                    key: "parameters".try_into()?,
-                    val: (from, to, amount).try_into()?,
-                });
-            }
-            Message(nonce, MessageWithoutNonce::Burn(from, amount)) => {
-                map.push(ScMapEntry {
-                    key: "domain".try_into()?,
-                    val: 3u32.into(),
-                });
-                map.push(ScMapEntry {
-                    key: "nonce".try_into()?,
-                    val: nonce.try_into()?,
-                });
-                map.push(ScMapEntry {
-                    key: "parameters".try_into()?,
-                    val: (from, amount).try_into()?,
-                });
-            }
-            Message(nonce, MessageWithoutNonce::Freeze(id)) => {
-                map.push(ScMapEntry {
-                    key: "domain".try_into()?,
-                    val: 4u32.into(),
-                });
-                map.push(ScMapEntry {
-                    key: "nonce".try_into()?,
-                    val: nonce.try_into()?,
-                });
-                map.push(ScMapEntry {
-                    key: "parameters".try_into()?,
-                    val: (id,).try_into()?,
-                });
-            }
-            Message(nonce, MessageWithoutNonce::Mint(to, amount)) => {
-                map.push(ScMapEntry {
-                    key: "domain".try_into()?,
-                    val: 5u32.into(),
-                });
-                map.push(ScMapEntry {
-                    key: "nonce".try_into()?,
-                    val: nonce.try_into()?,
-                });
-                map.push(ScMapEntry {
-                    key: "parameters".try_into()?,
-                    val: (to, amount).try_into()?,
-                });
-            }
-            Message(nonce, MessageWithoutNonce::SetAdministrator(id)) => {
-                map.push(ScMapEntry {
-                    key: "domain".try_into()?,
-                    val: 6u32.into(),
-                });
-                map.push(ScMapEntry {
-                    key: "nonce".try_into()?,
-                    val: nonce.try_into()?,
-                });
-                map.push(ScMapEntry {
-                    key: "parameters".try_into()?,
-                    val: (id,).try_into()?,
-                });
-            }
-            Message(nonce, MessageWithoutNonce::Unfreeze(id)) => {
-                map.push(ScMapEntry {
-                    key: "domain".try_into()?,
-                    val: 7u32.into(),
-                });
-                map.push(ScMapEntry {
-                    key: "nonce".try_into()?,
-                    val: nonce.try_into()?,
-                });
-                map.push(ScMapEntry {
-                    key: "parameters".try_into()?,
-                    val: (id,).try_into()?,
-                });
-            }
-        };
-        let scmap = ScVal::Object(Some(ScObject::Map(ScMap(map.try_into().map_err(|_| ())?))));
-        ("V0", scmap).try_into()
-    }
-}
-
-impl Message {
-    pub fn sign(&self, kp: &Keypair) -> Result<U512, ()> {
-        let mut buf = Vec::<u8>::new();
-        let val: ScVal = self.try_into()?;
-        val.write_xdr(&mut buf).map_err(|_| ())?;
-        Ok(kp.sign(&buf).to_bytes())
-    }
-}
-
-pub fn register_test_contract(e: &Env, contract_id: &U256) {
-    let mut bin = Binary::new(e);
-    for b in contract_id {
-        bin.push(*b);
+        approve(&mut self.env, &self.contract_id, &auth, spender, amount)
     }
 
-    e.register_contract(bin.into(), crate::contract::Token {});
-}
+    pub fn balance(&mut self, id: &Identifier) -> BigInt {
+        balance(&mut self.env, &self.contract_id, id)
+    }
 
-pub fn initialize(
-    e: &mut Env,
-    contract_id: &U256,
-    admin: &Identifier,
-    decimal: &u32,
-    name: &Binary,
-    symbol: &Binary,
-) {
-    e.invoke_contract_external(
-        HostFunction::Call,
-        (contract_id, "initialize", admin, decimal, name, symbol)
-            .try_into()
-            .unwrap(),
-    );
-}
+    pub fn is_frozen(&mut self, id: &Identifier) -> bool {
+        is_frozen(&mut self.env, &self.contract_id, id)
+    }
 
-pub fn nonce(e: &mut Env, contract_id: &U256, id: &Identifier) -> BigInt {
-    e.invoke_contract_external(
-        HostFunction::Call,
-        (contract_id, "nonce", id).try_into().unwrap(),
-    )
-    .try_into()
-    .unwrap()
-}
+    pub fn xfer(&mut self, from: &Keypair, to: &Identifier, amount: &BigInt) {
+        let mut args: Vec<EnvVal> = Vec::new(&self.env);
+        args.push(to.clone().into_env_val(&self.env));
+        args.push(amount.clone().into_env_val(&self.env));
+        let msg = Message::V0(MessageV0 {
+            nonce: self.nonce(&to_ed25519(&self.env, from)),
+            domain: crate::cryptography::Domain::Transfer as u32,
+            parameters: args,
+        });
+        let auth = KeyedAuthorization::Ed25519(KeyedEd25519Authorization {
+            public_key: FixedBinary::from_array(&self.env, from.public.to_bytes()),
+            signature: from.sign(msg).unwrap().try_into_val(&self.env).unwrap(),
+        });
+        xfer(&mut self.env, &self.contract_id, &auth, to, amount)
+    }
 
-pub fn allowance(
-    e: &mut Env,
-    contract_id: &U256,
-    from: &Identifier,
-    spender: &Identifier,
-) -> BigInt {
-    e.invoke_contract_external(
-        HostFunction::Call,
-        (contract_id, "allowance", from, spender)
-            .try_into()
-            .unwrap(),
-    )
-    .try_into()
-    .unwrap()
-}
+    pub fn xfer_from(
+        &mut self,
+        spender: &Keypair,
+        from: &Identifier,
+        to: &Identifier,
+        amount: &BigInt,
+    ) {
+        let mut args: Vec<EnvVal> = Vec::new(&self.env);
+        args.push(from.clone().into_env_val(&self.env));
+        args.push(to.clone().into_env_val(&self.env));
+        args.push(amount.clone().into_env_val(&self.env));
+        let msg = Message::V0(MessageV0 {
+            nonce: self.nonce(&to_ed25519(&self.env, spender)),
+            domain: crate::cryptography::Domain::TransferFrom as u32,
+            parameters: args,
+        });
+        let auth = KeyedAuthorization::Ed25519(KeyedEd25519Authorization {
+            public_key: FixedBinary::from_array(&self.env, spender.public.to_bytes()),
+            signature: spender.sign(msg).unwrap().try_into_val(&self.env).unwrap(),
+        });
+        xfer_from(&mut self.env, &self.contract_id, &auth, from, to, amount)
+    }
 
-pub fn approve(
-    e: &mut Env,
-    contract_id: &U256,
-    from: &KeyedAuthorization,
-    spender: &Identifier,
-    amount: &BigInt,
-) {
-    e.invoke_contract_external(
-        HostFunction::Call,
-        (contract_id, "approve", from, spender, amount)
-            .try_into()
-            .unwrap(),
-    );
-}
+    pub fn burn(&mut self, admin: &Keypair, from: &Identifier, amount: &BigInt) {
+        let mut args: Vec<EnvVal> = Vec::new(&self.env);
+        args.push(from.clone().into_env_val(&self.env));
+        args.push(amount.clone().into_env_val(&self.env));
+        let msg = Message::V0(MessageV0 {
+            nonce: self.nonce(&to_ed25519(&self.env, admin)),
+            domain: crate::cryptography::Domain::Burn as u32,
+            parameters: args,
+        });
+        let auth =
+            Authorization::Ed25519(admin.sign(msg).unwrap().try_into_val(&self.env).unwrap());
+        burn(&mut self.env, &self.contract_id, &auth, from, amount)
+    }
 
-pub fn balance(e: &mut Env, contract_id: &U256, id: &Identifier) -> BigInt {
-    e.invoke_contract_external(
-        HostFunction::Call,
-        (contract_id, "balance", id).try_into().unwrap(),
-    )
-    .try_into()
-    .unwrap()
-}
+    pub fn freeze(&mut self, admin: &Keypair, id: &Identifier) {
+        let mut args: Vec<EnvVal> = Vec::new(&self.env);
+        args.push(id.clone().into_env_val(&self.env));
+        let msg = Message::V0(MessageV0 {
+            nonce: self.nonce(&to_ed25519(&self.env, admin)),
+            domain: crate::cryptography::Domain::Freeze as u32,
+            parameters: args,
+        });
+        let auth =
+            Authorization::Ed25519(admin.sign(msg).unwrap().try_into_val(&self.env).unwrap());
+        freeze(&mut self.env, &self.contract_id, &auth, id)
+    }
 
-pub fn is_frozen(e: &mut Env, contract_id: &U256, id: &Identifier) -> bool {
-    e.invoke_contract_external(
-        HostFunction::Call,
-        (contract_id, "is_frozen", id).try_into().unwrap(),
-    )
-    .try_into()
-    .unwrap()
-}
+    pub fn mint(&mut self, admin: &Keypair, to: &Identifier, amount: &BigInt) {
+        let mut args: Vec<EnvVal> = Vec::new(&self.env);
+        args.push(to.clone().into_env_val(&self.env));
+        args.push(amount.clone().into_env_val(&self.env));
+        let msg = Message::V0(MessageV0 {
+            nonce: self.nonce(&to_ed25519(&self.env, admin)),
+            domain: crate::cryptography::Domain::Mint as u32,
+            parameters: args,
+        });
+        let auth =
+            Authorization::Ed25519(admin.sign(msg).unwrap().try_into_val(&self.env).unwrap());
+        mint(&mut self.env, &self.contract_id, &auth, to, amount)
+    }
 
-pub fn xfer(
-    e: &mut Env,
-    contract_id: &U256,
-    from: &KeyedAuthorization,
-    to: &Identifier,
-    amount: &BigInt,
-) {
-    e.invoke_contract_external(
-        HostFunction::Call,
-        (contract_id, "xfer", from, to, amount).try_into().unwrap(),
-    );
-}
+    pub fn set_admin(&mut self, admin: &Keypair, new_admin: &Identifier) {
+        let mut args: Vec<EnvVal> = Vec::new(&self.env);
+        args.push(new_admin.clone().into_env_val(&self.env));
+        let msg = Message::V0(MessageV0 {
+            nonce: self.nonce(&to_ed25519(&self.env, admin)),
+            domain: crate::cryptography::Domain::SetAdministrator as u32,
+            parameters: args,
+        });
+        let auth =
+            Authorization::Ed25519(admin.sign(msg).unwrap().try_into_val(&self.env).unwrap());
+        set_admin(&mut self.env, &self.contract_id, &auth, new_admin)
+    }
 
-pub fn xfer_from(
-    e: &mut Env,
-    contract_id: &U256,
-    spender: &KeyedAuthorization,
-    from: &Identifier,
-    to: &Identifier,
-    amount: &BigInt,
-) {
-    e.invoke_contract_external(
-        HostFunction::Call,
-        (contract_id, "xfer_from", spender, from, to, amount)
-            .try_into()
-            .unwrap(),
-    );
-}
+    pub fn unfreeze(&mut self, admin: &Keypair, id: &Identifier) {
+        let mut args: Vec<EnvVal> = Vec::new(&self.env);
+        args.push(id.clone().into_env_val(&self.env));
+        let msg = Message::V0(MessageV0 {
+            nonce: self.nonce(&to_ed25519(&self.env, admin)),
+            domain: crate::cryptography::Domain::Unfreeze as u32,
+            parameters: args,
+        });
+        let auth =
+            Authorization::Ed25519(admin.sign(msg).unwrap().try_into_val(&self.env).unwrap());
+        unfreeze(&mut self.env, &self.contract_id, &auth, id)
+    }
 
-pub fn burn(
-    e: &mut Env,
-    contract_id: &U256,
-    admin: &Authorization,
-    from: &Identifier,
-    amount: &BigInt,
-) {
-    e.invoke_contract_external(
-        HostFunction::Call,
-        (contract_id, "burn", admin, from, amount)
-            .try_into()
-            .unwrap(),
-    );
-}
+    pub fn decimals(&mut self) -> u32 {
+        decimals(&mut self.env, &self.contract_id)
+    }
 
-pub fn freeze(e: &mut Env, contract_id: &U256, admin: &Authorization, id: &Identifier) {
-    e.invoke_contract_external(
-        HostFunction::Call,
-        (contract_id, "freeze", admin, id).try_into().unwrap(),
-    );
-}
+    pub fn name(&mut self) -> Binary {
+        name(&mut self.env, &self.contract_id)
+    }
 
-pub fn mint(
-    e: &mut Env,
-    contract_id: &U256,
-    admin: &Authorization,
-    to: &Identifier,
-    amount: &BigInt,
-) {
-    e.invoke_contract_external(
-        HostFunction::Call,
-        (contract_id, "mint", admin, to, amount).try_into().unwrap(),
-    );
-}
-
-pub fn set_admin(e: &mut Env, contract_id: &U256, admin: &Authorization, new_admin: &Identifier) {
-    e.invoke_contract_external(
-        HostFunction::Call,
-        (contract_id, "set_admin", admin, new_admin)
-            .try_into()
-            .unwrap(),
-    );
-}
-
-pub fn unfreeze(e: &mut Env, contract_id: &U256, admin: &Authorization, id: &Identifier) {
-    e.invoke_contract_external(
-        HostFunction::Call,
-        (contract_id, "unfreeze", admin, id).try_into().unwrap(),
-    );
-}
-
-pub fn decimals(e: &mut Env, contract_id: &U256) -> u32 {
-    e.invoke_contract_external(
-        HostFunction::Call,
-        (contract_id, "decimals").try_into().unwrap(),
-    )
-    .try_into()
-    .unwrap()
-}
-
-pub fn name(e: &mut Env, contract_id: &U256) -> Binary {
-    e.invoke_contract_external(
-        HostFunction::Call,
-        (contract_id, "name").try_into().unwrap(),
-    )
-    .try_into_val(e)
-    .unwrap()
-}
-
-pub fn symbol(e: &mut Env, contract_id: &U256) -> Binary {
-    e.invoke_contract_external(
-        HostFunction::Call,
-        (contract_id, "symbol").try_into().unwrap(),
-    )
-    .try_into_val(e)
-    .unwrap()
+    pub fn symbol(&mut self) -> Binary {
+        symbol(&mut self.env, &self.contract_id)
+    }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,9 +1,10 @@
 use ed25519_dalek::Keypair;
-use external::MessageWithoutNonce as ContractFn;
-use num_bigint::BigInt;
 use rand::{thread_rng, RngCore};
-use stellar_contract_sdk::{Binary, Env};
-use stellar_token_contract::{external, external::Identifier};
+use stellar_contract_sdk::{BigInt, Binary, Env, FixedBinary};
+use stellar_token_contract::external::{
+    register_test_contract as register_token, to_ed25519, Token,
+};
+use stellar_token_contract::public_types::Authorization;
 
 fn generate_contract_id() -> [u8; 32] {
     let mut id: [u8; 32] = Default::default();
@@ -15,210 +16,66 @@ fn generate_keypair() -> Keypair {
     Keypair::generate(&mut thread_rng())
 }
 
-fn make_auth(kp: &Keypair, msg: &external::Message) -> external::Authorization {
-    let signature = msg.sign(kp).unwrap();
-    external::Authorization::Ed25519(signature)
-}
-
-fn make_keyed_auth(kp: &Keypair, msg: &external::Message) -> external::KeyedAuthorization {
-    use external::{KeyedAuthorization, KeyedEd25519Authorization};
-    let signature = msg.sign(kp).unwrap();
-    KeyedAuthorization::Ed25519(KeyedEd25519Authorization {
-        public_key: kp.public.to_bytes(),
-        signature,
-    })
-}
-
-struct Token(Env, [u8; 32]);
-
-impl Token {
-    fn initialize(&mut self, admin: &Identifier, decimal: u32, name: &str, symbol: &str) {
-        let n = Binary::from_slice(&mut self.0, name.as_bytes());
-        let s = Binary::from_slice(&mut self.0, symbol.as_bytes());
-        external::initialize(&mut self.0, &self.1, admin, &decimal, &n, &s);
-    }
-
-    fn nonce(&mut self, id: &Identifier) -> BigInt {
-        external::nonce(&mut self.0, &self.1, id)
-    }
-
-    fn allowance(&mut self, from: &Identifier, spender: &Identifier) -> BigInt {
-        external::allowance(&mut self.0, &self.1, from, spender)
-    }
-
-    fn approve(&mut self, from: &Keypair, spender: &Identifier, amount: BigInt) {
-        let from_id = Identifier::Ed25519(from.public.to_bytes());
-        let msg = external::Message(
-            self.nonce(&from_id),
-            ContractFn::Approve(spender.clone(), amount.clone()),
-        );
-        external::approve(
-            &mut self.0,
-            &self.1,
-            &make_keyed_auth(from, &msg),
-            spender,
-            &amount,
-        );
-    }
-
-    fn balance(&mut self, id: &Identifier) -> BigInt {
-        external::balance(&mut self.0, &self.1, id)
-    }
-
-    fn is_frozen(&mut self, id: &Identifier) -> bool {
-        external::is_frozen(&mut self.0, &self.1, id)
-    }
-
-    fn xfer(&mut self, from: &Keypair, to: &Identifier, amount: BigInt) {
-        let from_id = Identifier::Ed25519(from.public.to_bytes());
-        let msg = external::Message(
-            self.nonce(&from_id),
-            ContractFn::Transfer(to.clone(), amount.clone()),
-        );
-        external::xfer(
-            &mut self.0,
-            &self.1,
-            &make_keyed_auth(from, &msg),
-            to,
-            &amount,
-        );
-    }
-
-    fn xfer_from(&mut self, spender: &Keypair, from: &Identifier, to: &Identifier, amount: BigInt) {
-        let spender_id = Identifier::Ed25519(spender.public.to_bytes());
-        let msg = external::Message(
-            self.nonce(&spender_id),
-            ContractFn::TransferFrom(from.clone(), to.clone(), amount.clone()),
-        );
-        external::xfer_from(
-            &mut self.0,
-            &self.1,
-            &make_keyed_auth(spender, &msg),
-            from,
-            to,
-            &amount,
-        );
-    }
-
-    fn burn(&mut self, admin: &Keypair, from: &Identifier, amount: BigInt) {
-        let admin_id = Identifier::Ed25519(admin.public.to_bytes());
-        let msg = external::Message(
-            self.nonce(&admin_id),
-            ContractFn::Burn(from.clone(), amount.clone()),
-        );
-        external::burn(&mut self.0, &self.1, &make_auth(admin, &msg), from, &amount);
-    }
-
-    fn freeze(&mut self, admin: &Keypair, id: &Identifier) {
-        let admin_id = Identifier::Ed25519(admin.public.to_bytes());
-        let msg = external::Message(self.nonce(&admin_id), ContractFn::Freeze(id.clone()));
-        external::freeze(&mut self.0, &self.1, &make_auth(admin, &msg), id);
-    }
-
-    fn mint(&mut self, admin: &Keypair, to: &Identifier, amount: BigInt) {
-        let admin_id = Identifier::Ed25519(admin.public.to_bytes());
-        let msg = external::Message(
-            self.nonce(&admin_id),
-            ContractFn::Mint(to.clone(), amount.clone()),
-        );
-        external::mint(&mut self.0, &self.1, &make_auth(admin, &msg), to, &amount);
-    }
-
-    fn set_admin(&mut self, admin: &Keypair, new_admin: &Identifier) {
-        let admin_id = Identifier::Ed25519(admin.public.to_bytes());
-        let msg = external::Message(
-            self.nonce(&admin_id),
-            ContractFn::SetAdministrator(new_admin.clone()),
-        );
-        external::set_admin(&mut self.0, &self.1, &make_auth(admin, &msg), new_admin);
-    }
-
-    fn unfreeze(&mut self, admin: &Keypair, id: &Identifier) {
-        let admin_id = Identifier::Ed25519(admin.public.to_bytes());
-        let msg = external::Message(self.nonce(&admin_id), ContractFn::Unfreeze(id.clone()));
-        external::unfreeze(&mut self.0, &self.1, &make_auth(admin, &msg), id);
-    }
-
-    fn decimals(&mut self) -> u32 {
-        external::decimals(&mut self.0, &self.1)
-    }
-
-    fn name(&mut self) -> Binary {
-        external::name(&mut self.0, &self.1)
-    }
-
-    fn symbol(&mut self) -> Binary {
-        external::symbol(&mut self.0, &self.1)
-    }
-}
-
 #[test]
 fn test() {
     let e: Env = Default::default();
     let contract_id = generate_contract_id();
-    external::register_test_contract(&e, &contract_id);
-
-    let name = "name";
-    let symbol = "symbol";
-    let name_bin = Binary::from_slice(&e, name.as_bytes());
-    let symbol_bin = Binary::from_slice(&e, symbol.as_bytes());
-
-    let mut token = Token(e, contract_id.clone());
+    register_token(&e, &contract_id);
+    let mut token = Token::new(&e, &contract_id);
 
     let admin1 = generate_keypair();
+    let admin1_id = to_ed25519(&e, &admin1);
     let admin2 = generate_keypair();
+    let admin2_id = to_ed25519(&e, &admin2);
     let user1 = generate_keypair();
+    let user1_id = to_ed25519(&e, &user1);
     let user2 = generate_keypair();
+    let user2_id = to_ed25519(&e, &user2);
     let user3 = generate_keypair();
-    let admin1_id = Identifier::Ed25519(admin1.public.to_bytes());
-    let admin2_id = Identifier::Ed25519(admin2.public.to_bytes());
-    let user1_id = Identifier::Ed25519(user1.public.to_bytes());
-    let user2_id = Identifier::Ed25519(user2.public.to_bytes());
-    let user3_id = Identifier::Ed25519(user3.public.to_bytes());
+    let user3_id = to_ed25519(&e, &user3);
 
-    token.initialize(&admin1_id, 10, name, symbol);
+    token.initialize(&admin1_id, 7, "name", "symbol");
 
-    assert_eq!(token.decimals(), 10);
-    assert_eq!(token.name(), name_bin);
-    assert_eq!(token.symbol(), symbol_bin);
+    token.mint(&admin1, &user1_id, &BigInt::from_u32(&e, 1000));
+    assert_eq!(token.balance(&user1_id), BigInt::from_u32(&e, 1000));
+    assert_eq!(token.nonce(&admin1_id), BigInt::from_u32(&e, 1));
 
-    token.mint(&admin1, &user1_id, 1000u64.into());
-    assert_eq!(token.balance(&user1_id), 1000u64.into());
-    assert_eq!(token.nonce(&admin1_id), 1u64.into());
+    token.approve(&user2, &user3_id, &BigInt::from_u32(&e, 500));
+    assert_eq!(
+        token.allowance(&user2_id, &user3_id),
+        BigInt::from_u32(&e, 500)
+    );
+    assert_eq!(token.nonce(&user2_id), BigInt::from_u32(&e, 1));
 
-    token.approve(&user2, &user3_id, 500u64.into());
-    assert_eq!(token.allowance(&user2_id, &user3_id), 500u64.into());
-    assert_eq!(token.nonce(&user2_id), 1u64.into());
+    token.xfer(&user1, &user2_id, &BigInt::from_u32(&e, 600));
+    assert_eq!(token.balance(&user1_id), BigInt::from_u32(&e, 400));
+    assert_eq!(token.balance(&user2_id), BigInt::from_u32(&e, 600));
+    assert_eq!(token.nonce(&user1_id), BigInt::from_u32(&e, 1));
 
-    token.xfer(&user1, &user2_id, 600u64.into());
-    assert_eq!(token.balance(&user1_id), 400u64.into());
-    assert_eq!(token.balance(&user2_id), 600u64.into());
-    assert_eq!(token.nonce(&user1_id), 1u64.into());
+    token.xfer_from(&user3, &user2_id, &user1_id, &BigInt::from_u32(&e, 400));
+    assert_eq!(token.balance(&user1_id), BigInt::from_u32(&e, 800));
+    assert_eq!(token.balance(&user2_id), BigInt::from_u32(&e, 200));
+    assert_eq!(token.nonce(&user3_id), BigInt::from_u32(&e, 1));
 
-    token.xfer_from(&user3, &user2_id, &user1_id, 400u64.into());
-    assert_eq!(token.balance(&user1_id), 800u64.into());
-    assert_eq!(token.balance(&user2_id), 200u64.into());
-    assert_eq!(token.nonce(&user3_id), 1u64.into());
-
-    token.xfer(&user1, &user3_id, 300u64.into());
-    assert_eq!(token.balance(&user1_id), 500u64.into());
-    assert_eq!(token.balance(&user3_id), 300u64.into());
-    assert_eq!(token.nonce(&user1_id), 2u64.into());
+    token.xfer(&user1, &user3_id, &BigInt::from_u32(&e, 300));
+    assert_eq!(token.balance(&user1_id), BigInt::from_u32(&e, 500));
+    assert_eq!(token.balance(&user3_id), BigInt::from_u32(&e, 300));
+    assert_eq!(token.nonce(&user1_id), BigInt::from_u32(&e, 2));
 
     token.set_admin(&admin1, &admin2_id);
-    assert_eq!(token.nonce(&admin1_id), 2u64.into());
+    assert_eq!(token.nonce(&admin1_id), BigInt::from_u32(&e, 2));
 
     token.freeze(&admin2, &user2_id);
     assert_eq!(token.is_frozen(&user2_id), true);
-    assert_eq!(token.nonce(&admin2_id), 1u64.into());
+    assert_eq!(token.nonce(&admin2_id), BigInt::from_u32(&e, 1));
 
     token.unfreeze(&admin2, &user3_id);
     assert_eq!(token.is_frozen(&user3_id), false);
-    assert_eq!(token.nonce(&admin2_id), 2u64.into());
+    assert_eq!(token.nonce(&admin2_id), BigInt::from_u32(&e, 2));
 
-    token.burn(&admin2, &user3_id, 100u64.into());
-    assert_eq!(token.balance(&user3_id), 200u64.into());
-    assert_eq!(token.nonce(&admin2_id), 3u64.into());
+    token.burn(&admin2, &user3_id, &BigInt::from_u32(&e, 100));
+    assert_eq!(token.balance(&user3_id), BigInt::from_u32(&e, 200));
+    assert_eq!(token.nonce(&admin2_id), BigInt::from_u32(&e, 3));
 }
 
 #[test]
@@ -226,23 +83,23 @@ fn test() {
 fn xfer_insufficient_balance() {
     let e: Env = Default::default();
     let contract_id = generate_contract_id();
-    external::register_test_contract(&e, &contract_id);
-    let mut token = Token(e, contract_id.clone());
+    register_token(&e, &contract_id);
+    let mut token = Token::new(&e, &contract_id);
 
     let admin1 = generate_keypair();
     let user1 = generate_keypair();
     let user2 = generate_keypair();
-    let admin1_id = Identifier::Ed25519(admin1.public.to_bytes());
-    let user1_id = Identifier::Ed25519(user1.public.to_bytes());
-    let user2_id = Identifier::Ed25519(user2.public.to_bytes());
+    let admin1_id = to_ed25519(&e, &admin1);
+    let user1_id = to_ed25519(&e, &user1);
+    let user2_id = to_ed25519(&e, &user2);
 
     token.initialize(&admin1_id, 10, "name", "symbol");
 
-    token.mint(&admin1, &user1_id, 1000u64.into());
-    assert_eq!(token.balance(&user1_id), 1000u64.into());
-    assert_eq!(token.nonce(&admin1_id), 1u64.into());
+    token.mint(&admin1, &user1_id, &BigInt::from_u32(&e, 1000));
+    assert_eq!(token.balance(&user1_id), BigInt::from_u32(&e, 1000));
+    assert_eq!(token.nonce(&admin1_id), BigInt::from_u32(&e, 1));
 
-    token.xfer(&user1, &user2_id, 1001u64.into());
+    token.xfer(&user1, &user2_id, &BigInt::from_u32(&e, 1001));
 }
 
 #[test]
@@ -250,24 +107,24 @@ fn xfer_insufficient_balance() {
 fn xfer_receive_frozen() {
     let e: Env = Default::default();
     let contract_id = generate_contract_id();
-    external::register_test_contract(&e, &contract_id);
-    let mut token = Token(e, contract_id.clone());
+    register_token(&e, &contract_id);
+    let mut token = Token::new(&e, &contract_id);
 
     let admin1 = generate_keypair();
     let user1 = generate_keypair();
     let user2 = generate_keypair();
-    let admin1_id = Identifier::Ed25519(admin1.public.to_bytes());
-    let user1_id = Identifier::Ed25519(user1.public.to_bytes());
-    let user2_id = Identifier::Ed25519(user2.public.to_bytes());
+    let admin1_id = to_ed25519(&e, &admin1);
+    let user1_id = to_ed25519(&e, &user1);
+    let user2_id = to_ed25519(&e, &user2);
 
     token.initialize(&admin1_id, 10, "name", "symbol");
 
-    token.mint(&admin1, &user1_id, 1000u64.into());
-    assert_eq!(token.balance(&user1_id), 1000u64.into());
-    assert_eq!(token.nonce(&admin1_id), 1u64.into());
+    token.mint(&admin1, &user1_id, &BigInt::from_u32(&e, 1000));
+    assert_eq!(token.balance(&user1_id), BigInt::from_u32(&e, 1000));
+    assert_eq!(token.nonce(&admin1_id), BigInt::from_u32(&e, 1));
 
     token.freeze(&admin1, &user2_id);
-    token.xfer(&user1, &user2_id, 1u64.into());
+    token.xfer(&user1, &user2_id, &BigInt::from_u32(&e, 1));
 }
 
 #[test]
@@ -275,24 +132,24 @@ fn xfer_receive_frozen() {
 fn xfer_spend_frozen() {
     let e: Env = Default::default();
     let contract_id = generate_contract_id();
-    external::register_test_contract(&e, &contract_id);
-    let mut token = Token(e, contract_id.clone());
+    register_token(&e, &contract_id);
+    let mut token = Token::new(&e, &contract_id);
 
     let admin1 = generate_keypair();
     let user1 = generate_keypair();
     let user2 = generate_keypair();
-    let admin1_id = Identifier::Ed25519(admin1.public.to_bytes());
-    let user1_id = Identifier::Ed25519(user1.public.to_bytes());
-    let user2_id = Identifier::Ed25519(user2.public.to_bytes());
+    let admin1_id = to_ed25519(&e, &admin1);
+    let user1_id = to_ed25519(&e, &user1);
+    let user2_id = to_ed25519(&e, &user2);
 
     token.initialize(&admin1_id, 10, "name", "symbol");
 
-    token.mint(&admin1, &user1_id, 1000u64.into());
-    assert_eq!(token.balance(&user1_id), 1000u64.into());
-    assert_eq!(token.nonce(&admin1_id), 1u64.into());
+    token.mint(&admin1, &user1_id, &BigInt::from_u32(&e, 1000));
+    assert_eq!(token.balance(&user1_id), BigInt::from_u32(&e, 1000));
+    assert_eq!(token.nonce(&admin1_id), BigInt::from_u32(&e, 1));
 
     token.freeze(&admin1, &user1_id);
-    token.xfer(&user1, &user2_id, 1u64.into());
+    token.xfer(&user1, &user2_id, &BigInt::from_u32(&e, 1));
 }
 
 #[test]
@@ -300,29 +157,32 @@ fn xfer_spend_frozen() {
 fn xfer_from_insufficient_allowance() {
     let e: Env = Default::default();
     let contract_id = generate_contract_id();
-    external::register_test_contract(&e, &contract_id);
-    let mut token = Token(e, contract_id.clone());
+    register_token(&e, &contract_id);
+    let mut token = Token::new(&e, &contract_id);
 
     let admin1 = generate_keypair();
     let user1 = generate_keypair();
     let user2 = generate_keypair();
     let user3 = generate_keypair();
-    let admin1_id = Identifier::Ed25519(admin1.public.to_bytes());
-    let user1_id = Identifier::Ed25519(user1.public.to_bytes());
-    let user2_id = Identifier::Ed25519(user2.public.to_bytes());
-    let user3_id = Identifier::Ed25519(user3.public.to_bytes());
+    let admin1_id = to_ed25519(&e, &admin1);
+    let user1_id = to_ed25519(&e, &user1);
+    let user2_id = to_ed25519(&e, &user2);
+    let user3_id = to_ed25519(&e, &user3);
 
     token.initialize(&admin1_id, 10, "name", "symbol");
 
-    token.mint(&admin1, &user1_id, 1000u64.into());
-    assert_eq!(token.balance(&user1_id), 1000u64.into());
-    assert_eq!(token.nonce(&admin1_id), 1u64.into());
+    token.mint(&admin1, &user1_id, &BigInt::from_u32(&e, 1000));
+    assert_eq!(token.balance(&user1_id), BigInt::from_u32(&e, 1000));
+    assert_eq!(token.nonce(&admin1_id), BigInt::from_u32(&e, 1));
 
-    token.approve(&user1, &user3_id, 100u64.into());
-    assert_eq!(token.allowance(&user1_id, &user3_id), 100u64.into());
-    assert_eq!(token.nonce(&user1_id), 1u64.into());
+    token.approve(&user1, &user3_id, &BigInt::from_u32(&e, 100));
+    assert_eq!(
+        token.allowance(&user1_id, &user3_id),
+        BigInt::from_u32(&e, 100)
+    );
+    assert_eq!(token.nonce(&user1_id), BigInt::from_u32(&e, 1));
 
-    token.xfer_from(&user3, &user1_id, &user2_id, 101u64.into());
+    token.xfer_from(&user3, &user1_id, &user2_id, &BigInt::from_u32(&e, 101));
 }
 
 #[test]
@@ -330,11 +190,11 @@ fn xfer_from_insufficient_allowance() {
 fn initialize_already_initialized() {
     let e: Env = Default::default();
     let contract_id = generate_contract_id();
-    external::register_test_contract(&e, &contract_id);
-    let mut token = Token(e, contract_id.clone());
+    register_token(&e, &contract_id);
+    let mut token = Token::new(&e, &contract_id);
 
     let admin1 = generate_keypair();
-    let admin1_id = Identifier::Ed25519(admin1.public.to_bytes());
+    let admin1_id = to_ed25519(&e, &admin1);
 
     token.initialize(&admin1_id, 10, "name", "symbol");
     token.initialize(&admin1_id, 10, "name", "symbol");
@@ -343,22 +203,23 @@ fn initialize_already_initialized() {
 #[test]
 #[should_panic] // TODO: Add expected
 fn set_admin_bad_signature() {
-    let e: Env = Default::default();
+    let mut e: Env = Default::default();
     let contract_id = generate_contract_id();
-    external::register_test_contract(&e, &contract_id);
-    let mut token = Token(e, contract_id.clone());
+    register_token(&e, &contract_id);
+    let mut token = Token::new(&e, &contract_id);
 
     let admin1 = generate_keypair();
     let admin2 = generate_keypair();
-    let admin1_id = Identifier::Ed25519(admin1.public.to_bytes());
-    let admin2_id = Identifier::Ed25519(admin2.public.to_bytes());
+    let admin1_id = to_ed25519(&e, &admin1);
+    let admin2_id = to_ed25519(&e, &admin2);
 
     token.initialize(&admin1_id, 10, "name", "symbol");
 
     let mut signature: [u8; 64] = vec![0; 64].as_slice().try_into().unwrap();
     thread_rng().fill_bytes(&mut signature);
-    let auth = external::Authorization::Ed25519(signature);
-    external::set_admin(&mut token.0, &token.1, &auth, &admin2_id);
+    let auth = Authorization::Ed25519(FixedBinary::from_array(&e, signature));
+    let contract_id_bin = Binary::from_slice(&e, &contract_id);
+    stellar_token_contract::external::set_admin(&mut e, &contract_id_bin, &auth, &admin2_id);
 }
 
 #[test]
@@ -366,11 +227,11 @@ fn set_admin_bad_signature() {
 fn decimal_is_over_max() {
     let e = Default::default();
     let contract_id = generate_contract_id();
-    external::register_test_contract(&e, &contract_id);
-    let mut token = Token(e, contract_id.clone());
+    register_token(&e, &contract_id);
+    let mut token = Token::new(&e, &contract_id);
 
     let admin1 = generate_keypair();
-    let admin1_id = Identifier::Ed25519(admin1.public.to_bytes());
+    let admin1_id = to_ed25519(&e, &admin1);
 
     token.initialize(&admin1_id, u32::from(u8::MAX) + 1, "name", "symbol");
 }


### PR DESCRIPTION
### What

Take advantage of the macro-generated code for `invoke_external`. Rewrite external.rs to leverage this machinery, providing a better test interface. Update tests to use the new test interface.

### Why

At this point, external types no longer exist. All testing is done through SDK types.

Resolves https://github.com/stellar/rs-stellar-token-contract/issues/23

### Known limitations

None