### PR TITLE
More cleaning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,11 +591,9 @@ name = "stellar-token-contract"
 version = "0.0.0"
 dependencies = [
  "ed25519-dalek",
- "num-bigint",
  "rand",
  "stellar-contract-sdk",
  "stellar-token-contract",
- "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=94e01c7b)",
 ]
 
 [[package]]
@@ -611,9 +609,6 @@ dependencies = [
 name = "stellar-xdr"
 version = "0.0.0"
 source = "git+https://github.com/stellar/rs-stellar-xdr?rev=94e01c7b#94e01c7bbb3622e12907e1ceb95ab85f4e55e085"
-dependencies = [
- "num-bigint",
-]
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,12 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = ["export"]
 export = []
-testutils = ["stellar-contract-sdk/testutils", "dep:ed25519-dalek", "dep:num-bigint", "dep:stellar-xdr", "stellar-xdr?/num-bigint"]
+testutils = ["stellar-contract-sdk/testutils", "dep:ed25519-dalek"]
 
 [dependencies]
 ed25519-dalek = { version = "1.0.1", optional = true }
-num-bigint = { version = "0.4", optional = true }
 stellar-contract-sdk = { git = "https://github.com/stellar/rs-stellar-contract-sdk", rev = "764fc12" }
 # stellar-contract-sdk = { path = "../rs-stellar-contract-sdk/sdk" }
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "94e01c7b", features = ["next"], optional = true }
-# stellar-xdr = { path = "../rs-stellar-xdr", features = ["next"], optional = true }
 
 [dev-dependencies]
 stellar-token-contract = { path = ".", features = ["export", "testutils"] }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -136,12 +136,7 @@ impl TokenTrait for Token {
 
     fn freeze(e: Env, admin: Authorization, id: Identifier) {
         let auth = to_administrator_authorization(&e, admin);
-        check_auth(
-            &e,
-            auth,
-            Domain::Freeze,
-            (id.clone(),).clone().into_env_val(&e),
-        );
+        check_auth(&e, auth, Domain::Freeze, (id.clone(),).into_env_val(&e));
         write_state(&e, id, true);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,3 +14,5 @@ mod nonce;
 pub mod public_types;
 mod storage_types;
 pub mod testutils;
+
+pub use cryptography::Domain;

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "testutils")]
 
+use crate::cryptography::Domain;
 use crate::public_types::{
     Authorization, Identifier, KeyedAuthorization, KeyedEd25519Authorization, Message, MessageV0,
 };
@@ -73,7 +74,7 @@ impl Token {
         args.push(amount.clone().into_env_val(&self.env));
         let msg = Message::V0(MessageV0 {
             nonce: self.nonce(&to_ed25519(&self.env, from)),
-            domain: crate::cryptography::Domain::Approve as u32,
+            domain: Domain::Approve as u32,
             parameters: args,
         });
         let auth = KeyedAuthorization::Ed25519(KeyedEd25519Authorization {
@@ -97,7 +98,7 @@ impl Token {
         args.push(amount.clone().into_env_val(&self.env));
         let msg = Message::V0(MessageV0 {
             nonce: self.nonce(&to_ed25519(&self.env, from)),
-            domain: crate::cryptography::Domain::Transfer as u32,
+            domain: Domain::Transfer as u32,
             parameters: args,
         });
         let auth = KeyedAuthorization::Ed25519(KeyedEd25519Authorization {
@@ -120,7 +121,7 @@ impl Token {
         args.push(amount.clone().into_env_val(&self.env));
         let msg = Message::V0(MessageV0 {
             nonce: self.nonce(&to_ed25519(&self.env, spender)),
-            domain: crate::cryptography::Domain::TransferFrom as u32,
+            domain: Domain::TransferFrom as u32,
             parameters: args,
         });
         let auth = KeyedAuthorization::Ed25519(KeyedEd25519Authorization {
@@ -136,7 +137,7 @@ impl Token {
         args.push(amount.clone().into_env_val(&self.env));
         let msg = Message::V0(MessageV0 {
             nonce: self.nonce(&to_ed25519(&self.env, admin)),
-            domain: crate::cryptography::Domain::Burn as u32,
+            domain: Domain::Burn as u32,
             parameters: args,
         });
         let auth =
@@ -149,7 +150,7 @@ impl Token {
         args.push(id.clone().into_env_val(&self.env));
         let msg = Message::V0(MessageV0 {
             nonce: self.nonce(&to_ed25519(&self.env, admin)),
-            domain: crate::cryptography::Domain::Freeze as u32,
+            domain: Domain::Freeze as u32,
             parameters: args,
         });
         let auth =
@@ -163,7 +164,7 @@ impl Token {
         args.push(amount.clone().into_env_val(&self.env));
         let msg = Message::V0(MessageV0 {
             nonce: self.nonce(&to_ed25519(&self.env, admin)),
-            domain: crate::cryptography::Domain::Mint as u32,
+            domain: Domain::Mint as u32,
             parameters: args,
         });
         let auth =
@@ -176,7 +177,7 @@ impl Token {
         args.push(new_admin.clone().into_env_val(&self.env));
         let msg = Message::V0(MessageV0 {
             nonce: self.nonce(&to_ed25519(&self.env, admin)),
-            domain: crate::cryptography::Domain::SetAdministrator as u32,
+            domain: Domain::SetAdministrator as u32,
             parameters: args,
         });
         let auth =
@@ -189,7 +190,7 @@ impl Token {
         args.push(id.clone().into_env_val(&self.env));
         let msg = Message::V0(MessageV0 {
             nonce: self.nonce(&to_ed25519(&self.env, admin)),
-            domain: crate::cryptography::Domain::Unfreeze as u32,
+            domain: Domain::Unfreeze as u32,
             parameters: args,
         });
         let auth =


### PR DESCRIPTION
### What

- Clean up use of `crate::cryptography::Domain` in testutils, export `Domain`
- Clean up clone-clone in freeze
- Remove num-bigint and stellar_xdr dependencies

### Why

General tidying.

### Known limitations

None